### PR TITLE
Remove redundant header globe icon

### DIFF
--- a/lib/screens/Events/single_event_screen.dart
+++ b/lib/screens/Events/single_event_screen.dart
@@ -2157,41 +2157,6 @@ https://outlook.live.com/calendar/0/deeplink/compose?subject=${Uri.encodeCompone
                     ),
                     const SizedBox(width: 12),
                     Tooltip(
-                      message: 'View Event Location',
-                      child: GestureDetector(
-                        onTap: () {
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder: (context) => EventLocationViewScreen(
-                                eventModel: eventModel,
-                              ),
-                            ),
-                          );
-                        },
-                        child: Container(
-                          width: 40,
-                          height: 40,
-                          decoration: BoxDecoration(
-                            color: Colors.white.withAlpha((0.2 * 255).round()),
-                            borderRadius: BorderRadius.circular(20),
-                            border: Border.all(
-                              color: Colors.white.withAlpha(
-                                (0.3 * 255).round(),
-                              ),
-                              width: 1,
-                            ),
-                          ),
-                          child: const Icon(
-                            Icons.public,
-                            color: Colors.white,
-                            size: 20,
-                          ),
-                        ),
-                      ),
-                    ),
-                    const SizedBox(width: 12),
-                    Tooltip(
                       message: 'Share Event',
                       child: GestureDetector(
                         onTap: () => _showQuickShareOptions(),
@@ -2289,41 +2254,6 @@ https://outlook.live.com/calendar/0/deeplink/compose?subject=${Uri.encodeCompone
                                       : Colors.white,
                                   size: 20,
                                 ),
-                        ),
-                      ),
-                    ),
-                    const SizedBox(width: 12),
-                    Tooltip(
-                      message: 'View Event Location',
-                      child: GestureDetector(
-                        onTap: () {
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder: (context) => EventLocationViewScreen(
-                                eventModel: eventModel,
-                              ),
-                            ),
-                          );
-                        },
-                        child: Container(
-                          width: 40,
-                          height: 40,
-                          decoration: BoxDecoration(
-                            color: Colors.white.withAlpha((0.2 * 255).round()),
-                            borderRadius: BorderRadius.circular(20),
-                            border: Border.all(
-                              color: Colors.white.withAlpha(
-                                (0.3 * 255).round(),
-                              ),
-                              width: 1,
-                            ),
-                          ),
-                          child: const Icon(
-                            Icons.public,
-                            color: Colors.white,
-                            size: 20,
-                          ),
                         ),
                       ),
                     ),


### PR DESCRIPTION
Remove the globe icon button from the SingleEventScreen header because it is redundant with the globe icon next to the event location.

---
<a href="https://cursor.com/background-agent?bcId=bc-a198741e-fc96-4468-a792-0b0ae916dcee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a198741e-fc96-4468-a792-0b0ae916dcee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

