### PR TITLE
Enable scrolling for search results in home screen

### DIFF
--- a/lib/screens/Home/home_screen.dart
+++ b/lib/screens/Home/home_screen.dart
@@ -1172,8 +1172,8 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
     }
 
     return ListView.builder(
-      shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(),
+      physics: const AlwaysScrollableScrollPhysics(),
+      padding: const EdgeInsets.symmetric(vertical: 0),
       itemCount: events.length,
       itemBuilder: (context, index) {
         return Padding(
@@ -1199,8 +1199,8 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
     }
 
     return ListView.builder(
-      shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(),
+      physics: const AlwaysScrollableScrollPhysics(),
+      padding: const EdgeInsets.symmetric(vertical: 0),
       itemCount: _searchEvents.length,
       itemBuilder: (context, index) {
         return Padding(
@@ -1221,8 +1221,8 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
     }
 
     return ListView.builder(
-      shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(),
+      physics: const AlwaysScrollableScrollPhysics(),
+      padding: const EdgeInsets.symmetric(vertical: 0),
       itemCount: _searchUsers.length,
       itemBuilder: (context, index) {
         return Padding(
@@ -1527,8 +1527,8 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
     }
 
     return ListView.builder(
-      shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(),
+      physics: const AlwaysScrollableScrollPhysics(),
+      padding: const EdgeInsets.symmetric(vertical: 0),
       itemCount: _defaultEvents.length,
       itemBuilder: (context, index) {
         return Padding(
@@ -1581,8 +1581,8 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
     }
 
     return ListView.builder(
-      shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(),
+      physics: const AlwaysScrollableScrollPhysics(),
+      padding: const EdgeInsets.symmetric(vertical: 0),
       itemCount: _defaultUsers.length,
       itemBuilder: (context, index) {
         final user = _defaultUsers[index];


### PR DESCRIPTION
Enable scrolling for search results and default content lists in the Home screen search overlay by updating ListView physics.

The `ListView.builder` widgets within the search overlay were configured with `NeverScrollableScrollPhysics` and `shrinkWrap: true`, which prevented them from scrolling. Changing to `AlwaysScrollableScrollPhysics` and removing `shrinkWrap` allows the lists to take available space and scroll normally.

---
<a href="https://cursor.com/background-agent?bcId=bc-2492b17c-7f8d-4c20-9adf-8c91c2f8371d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2492b17c-7f8d-4c20-9adf-8c91c2f8371d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

