### PR TITLE
Fix single event screen errors

### DIFF
--- a/lib/screens/Events/single_event_screen.dart
+++ b/lib/screens/Events/single_event_screen.dart
@@ -104,9 +104,11 @@ class _SingleEventScreenState extends State<SingleEventScreen>
     await FirebaseFirestoreHelper()
         .getPreRegisterAttendanceCount(eventId: eventModel.id)
         .then((countValue) {
-          setState(() {
-            preRegisteredCount = countValue;
-          });
+          if (mounted) {
+            setState(() {
+              preRegisteredCount = countValue;
+            });
+          }
         });
   }
 
@@ -115,9 +117,11 @@ class _SingleEventScreenState extends State<SingleEventScreen>
       final attendanceList = await FirebaseFirestoreHelper().getAttendance(
         eventId: eventModel.id,
       );
-      setState(() {
-        actualAttendanceCount = attendanceList.length;
-      });
+      if (mounted) {
+        setState(() {
+          actualAttendanceCount = attendanceList.length;
+        });
+      }
     } catch (e) {
       if (kDebugMode) {
         Logger.error('Error getting actual attendance: $e');
@@ -131,9 +135,11 @@ class _SingleEventScreenState extends State<SingleEventScreen>
         eventId: eventModel.id,
       );
       final usedTickets = ticketsList.where((ticket) => ticket.isUsed).length;
-      setState(() {
-        usedTicketsCount = usedTickets;
-      });
+      if (mounted) {
+        setState(() {
+          usedTicketsCount = usedTickets;
+        });
+      }
     } catch (e) {
       if (kDebugMode) {
         Logger.error('Error getting used tickets: $e');
@@ -142,9 +148,11 @@ class _SingleEventScreenState extends State<SingleEventScreen>
   }
 
   Future<void> loadEventSummary() async {
-    setState(() {
-      isLoadingSummary = true;
-    });
+    if (mounted) {
+      setState(() {
+        isLoadingSummary = true;
+      });
+    }
 
     await Future.wait([
       getPreRegisterCount(),
@@ -152,9 +160,11 @@ class _SingleEventScreenState extends State<SingleEventScreen>
       getUsedTicketsCount(),
     ]);
 
-    setState(() {
-      isLoadingSummary = false;
-    });
+    if (mounted) {
+      setState(() {
+        isLoadingSummary = false;
+      });
+    }
   }
 
   bool isInInRadius(LatLng center, double radiusInFeet, LatLng point) {
@@ -180,9 +190,11 @@ class _SingleEventScreenState extends State<SingleEventScreen>
       value,
     ) {
       Logger.debug('Exist value is $value');
-      setState(() {
-        signedIn = value;
-      });
+      if (mounted) {
+        setState(() {
+          signedIn = value;
+        });
+      }
 
       // Only show sign-in dialog if user is not signed in and meets all conditions
       // and hasn't just signed in (to prevent showing dialog immediately after sign-in)
@@ -429,7 +441,7 @@ class _SingleEventScreenState extends State<SingleEventScreen>
         eventModel.radius,
         newLatLng,
       );
-      if (inRadius) {
+      if (inRadius && mounted) {
         _showSignInDialog();
       }
       Logger.debug(
@@ -702,22 +714,26 @@ class _SingleEventScreenState extends State<SingleEventScreen>
       ShowToast().showNormalToast(msg: 'Signed In Successfully!');
 
       // Pop the sign-in dialog
-      if (Navigator.canPop(context)) {
+      if (mounted && Navigator.canPop(context)) {
         Navigator.of(context).pop();
       }
 
       // Refresh event details to update UI
 
-      setState(() {
-        _justSignedIn = true;
-      });
+      if (mounted) {
+        setState(() {
+          _justSignedIn = true;
+        });
+      }
 
       // Reset the button and the flag after a delay
       Future.delayed(const Duration(seconds: 2), () {
         _btnCtlr.reset();
-        setState(() {
-          _justSignedIn = false;
-        });
+        if (mounted) {
+          setState(() {
+            _justSignedIn = false;
+          });
+        }
       });
 
       // Show privacy dialog for dwell tracking if event has location enabled
@@ -1047,7 +1063,9 @@ class _SingleEventScreenState extends State<SingleEventScreen>
 
                       // Close modal and perform sign-in
                       Navigator.pop(context);
-                      await _performSignIn(attendanceModel);
+                      if (mounted) {
+                        await _performSignIn(attendanceModel);
+                      }
                     } else {
                       modalBtnController.reset();
                     }


### PR DESCRIPTION
Add `mounted` checks to prevent `BuildContext` usage across async gaps in `single_event_screen.dart`.

---
<a href="https://cursor.com/background-agent?bcId=bc-e11b8cc9-04c9-4719-a961-7aa35583b7e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e11b8cc9-04c9-4719-a961-7aa35583b7e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

