### PR TITLE
Extract and update event location from screenshot

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   syncfusion_flutter_xlsio: ^29.2.11
   google_maps_flutter: ^2.10.0
   geolocator: ^11.0.0
+  geocoding: ^3.0.0
   permission_handler: ^12.0.0+1
   webview_flutter: ^4.7.0
   url_launcher: ^6.3.0


### PR DESCRIPTION
Display the actual street address of an event by performing reverse geocoding from its coordinates. This replaces placeholder text with precise location information, enhancing user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-c6ae1e06-13a7-41e5-939d-b28cd026981a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c6ae1e06-13a7-41e5-939d-b28cd026981a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

