### PR TITLE
Fix emulator app installation error

### DIFF
--- a/ADB_TROUBLESHOOTING_GUIDE.md
+++ b/ADB_TROUBLESHOOTING_GUIDE.md
@@ -1,0 +1,160 @@
+# Flutter ADB Installation Issue - Troubleshooting Guide
+
+## Problem
+You're getting the following error when running your Flutter app on the Android emulator:
+```
+Error: ADB exited with exit code 1
+adb: failed to install app-debug.apk: cmd: Failure calling service package: Broken pipe (32)
+```
+
+## Quick Fixes (Try These First)
+
+### 1. Restart ADB Server
+```bash
+adb kill-server
+adb start-server
+adb devices
+flutter run
+```
+
+### 2. Clean and Rebuild
+```bash
+flutter clean
+flutter pub get
+flutter run
+```
+
+### 3. Restart Emulator
+- Close the Android emulator completely
+- Restart it from Android Studio or command line
+- Wait for it to fully boot up
+- Try running the app again
+
+## Detailed Troubleshooting Steps
+
+### Step 1: Check Emulator Status
+```bash
+# Check connected devices
+adb devices
+
+# Should show something like:
+# List of devices attached
+# emulator-5554    device
+```
+
+### Step 2: Clear App Data on Emulator
+```bash
+# Clear your app's data on the emulator
+adb shell pm clear com.stormdeve.orgami
+```
+
+### Step 3: Manual Installation Test
+```bash
+# Try installing the APK manually
+adb install -r build/app/outputs/flutter-apk/app-debug.apk
+```
+
+### Step 4: Emulator Storage Check
+The "Broken pipe" error often occurs when the emulator is out of storage space.
+
+**Solution A: Increase Emulator Storage**
+1. Open Android Studio
+2. Go to Tools → AVD Manager
+3. Click the pencil icon next to your emulator
+4. Click "Advanced Settings"
+5. Increase "Internal Storage" (try 8GB+)
+6. Increase "SD Card" size if needed
+
+**Solution B: Wipe Emulator Data**
+1. In AVD Manager, click the down arrow next to your emulator
+2. Select "Wipe Data"
+3. Restart the emulator
+
+### Step 5: Alternative Emulator
+If the issue persists, try creating a new emulator:
+1. Android Studio → Tools → AVD Manager
+2. Create Virtual Device
+3. Choose a different API level (API 30 or 31 work well)
+4. Ensure adequate storage (6GB+ internal)
+
+### Step 6: Physical Device Testing
+Test on a physical Android device to isolate if it's an emulator-specific issue:
+1. Enable Developer Options on your phone
+2. Enable USB Debugging
+3. Connect via USB
+4. Run `adb devices` to confirm connection
+5. Run `flutter run`
+
+## Advanced Solutions
+
+### Update Android SDK Tools
+```bash
+# Update platform-tools
+sdkmanager --update
+sdkmanager "platform-tools"
+```
+
+### Check ADB Version
+```bash
+adb version
+# Should show recent version (30+)
+```
+
+### Force Flutter to Use Specific Device
+```bash
+# List devices
+flutter devices
+
+# Run on specific device
+flutter run -d device_id
+```
+
+### Gradle Clean (if build issues persist)
+```bash
+cd android
+./gradlew clean
+cd ..
+flutter clean
+flutter pub get
+flutter run
+```
+
+## Prevention Tips
+
+1. **Regular Emulator Maintenance**
+   - Periodically wipe emulator data
+   - Keep adequate free space (2GB+)
+   - Close unused apps in emulator
+
+2. **Project Maintenance**
+   - Run `flutter clean` regularly
+   - Keep Flutter/Android SDK updated
+   - Clear build cache when switching branches
+
+3. **Emulator Configuration**
+   - Use recommended API levels (29-33)
+   - Allocate sufficient RAM (4GB+)
+   - Enable hardware acceleration
+
+## Still Having Issues?
+
+If none of these solutions work, please provide:
+1. Output of `flutter doctor -v`
+2. Output of `adb devices`
+3. Android Studio version
+4. Emulator configuration details
+5. Host OS version
+
+## Quick Commands Summary
+```bash
+# Emergency reset sequence
+adb kill-server
+adb start-server
+flutter clean
+flutter pub get
+flutter run
+
+# If that fails, restart emulator and try:
+adb devices
+flutter run -v  # verbose output for debugging
+```

--- a/PROJECT_SPECIFIC_FIX.md
+++ b/PROJECT_SPECIFIC_FIX.md
@@ -1,0 +1,159 @@
+# Project-Specific ADB Installation Fix
+
+Based on your project configuration, here are specific recommendations for your Orgami Flutter app:
+
+## Identified Configuration Details
+
+Your app uses:
+- **Package Name**: `com.stormdeve.orgami`
+- **Target SDK**: 36 (very recent - might cause compatibility issues)
+- **Min SDK**: 23
+- **Compile SDK**: 36
+- **Gradle**: 8.8
+- **Java**: Version 17
+- **Kotlin**: 1.9.22
+
+## Most Likely Causes & Solutions
+
+### 1. Target SDK 36 Compatibility Issue ⚠️
+Your app targets SDK 36, which is very recent and might not be fully supported by older emulators.
+
+**Solution A - Use Compatible Emulator:**
+```bash
+# Create emulator with API 34 or 35
+# In Android Studio: AVD Manager → Create → API 34/35
+```
+
+**Solution B - Temporarily Lower Target SDK (if needed):**
+Edit `android/app/build.gradle`:
+```gradle
+defaultConfig {
+    targetSdk = 34  // Change from 36 to 34
+}
+```
+
+### 2. Clear App Data Specifically
+```bash
+adb shell pm clear com.stormdeve.orgami
+```
+
+### 3. Firebase Setup Check
+Since your app uses Firebase, ensure:
+```bash
+# Check if Firebase is causing conflicts
+adb shell pm clear com.google.android.gms
+# Then try installing again
+flutter run
+```
+
+### 4. Permission-Heavy App Fix
+Your app uses many permissions (location, camera, storage). Try:
+```bash
+# Reset all permissions
+adb shell pm reset-permissions
+flutter run
+```
+
+## Recommended Emulator Setup
+
+Create a new emulator with these specs:
+- **API Level**: 34 (Android 14)
+- **Target**: Google APIs (not just Android)
+- **RAM**: 4GB minimum
+- **Internal Storage**: 8GB+
+- **Architecture**: x86_64 (if available)
+
+## Quick Fix Sequence
+
+Try these commands in order:
+
+```bash
+# 1. Kill everything
+adb kill-server
+pkill -f emulator
+
+# 2. Start fresh
+adb start-server
+# Start your emulator manually
+
+# 3. Wait for full boot, then:
+adb devices
+# Should show "device" not "offline"
+
+# 4. Clear your app
+adb shell pm clear com.stormdeve.orgami
+
+# 5. Clean build
+flutter clean
+flutter pub get
+
+# 6. Run with verbose output
+flutter run -v
+```
+
+## Alternative Installation Method
+
+If the above doesn't work, try manual installation:
+
+```bash
+# 1. Build APK
+flutter build apk --debug
+
+# 2. Install manually with force
+adb install -r -d build/app/outputs/flutter-apk/app-debug.apk
+
+# 3. Launch manually
+adb shell monkey -p com.stormdeve.orgami -c android.intent.category.LAUNCHER 1
+```
+
+## If Still Failing - Compatibility Check
+
+Your project has very recent dependencies. If issues persist:
+
+1. **Test on Physical Device**: The issue might be emulator-specific
+2. **Create Simple Test App**: Test if it's project-specific:
+   ```bash
+   flutter create test_app
+   cd test_app
+   flutter run  # If this works, it's your project config
+   ```
+
+3. **Check Flutter Doctor**: Ensure your setup is valid:
+   ```bash
+   flutter doctor -v
+   flutter doctor --android-licenses
+   ```
+
+## Emergency Downgrade (Last Resort)
+
+If nothing else works, you can temporarily downgrade SDK versions:
+
+In `android/app/build.gradle`:
+```gradle
+android {
+    compileSdk = 34  // instead of 36
+    
+    defaultConfig {
+        targetSdk = 34  // instead of 36
+    }
+}
+```
+
+Then:
+```bash
+flutter clean
+flutter pub get
+flutter run
+```
+
+> **Note**: SDK 36 is very new (released late 2024). Most emulators and devices might not fully support it yet. Consider using SDK 34 for better compatibility.
+
+## Success Indicators
+
+You'll know it's fixed when you see:
+```
+✓ Built build/app/outputs/flutter-apk/app-debug.apk
+Installing build/app/outputs/flutter-apk/app-debug.apk...
+✓ App installed successfully  <-- This line should appear
+Launching lib/main.dart on sdk gphone64 arm64 in debug mode...
+```


### PR DESCRIPTION
Add ADB troubleshooting guides to resolve emulator installation errors.

The guides address the "Broken pipe (32)" error, which was likely caused by compatibility issues with Android SDK 36 on the emulator, providing steps to resolve it through emulator configuration and SDK version adjustments.

---
<a href="https://cursor.com/background-agent?bcId=bc-c9e8ad0b-2022-4801-a36c-7ff20dfc8fc5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c9e8ad0b-2022-4801-a36c-7ff20dfc8fc5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

