### PR TITLE
Implement user follow and unfollow functionality

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -8,13 +8,29 @@ service cloud.firestore {
     
     // Allow users to read/write their own customer data
     // Users can only access their own customer document
-    match /Customers/{customerId} {
-      allow read, write: if request.auth != null && request.auth.uid == customerId;
+    match /Customers/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
       allow create: if request.auth != null && request.auth.uid == request.resource.data.uid;
       // Allow access to special customer documents for manual/without_login users
-      allow read, write: if request.auth != null && (customerId == 'manual' || customerId == 'without_login');
+      allow read, write: if request.auth != null && (userId == 'manual' || userId == 'without_login');
       // Allow reading any customer document for authenticated users (for debugging)
       allow read: if request.auth != null;
+
+      // Followers subcollection: allow public reads; writes by follower or profile owner
+      match /followers/{followerId} {
+        allow read: if request.auth != null;
+        allow create: if request.auth != null && request.auth.uid == followerId;
+        allow delete: if request.auth != null && (request.auth.uid == followerId || request.auth.uid == userId);
+        allow update: if false;
+      }
+
+      // Following subcollection: allow public reads; only the owner can modify their following
+      match /following/{followingId} {
+        allow read: if request.auth != null;
+        allow create: if request.auth != null && request.auth.uid == userId;
+        allow delete: if request.auth != null && request.auth.uid == userId;
+        allow update: if false;
+      }
     }
     
     // Allow authenticated users to access Settings collection for app configuration


### PR DESCRIPTION
Updates Firestore rules and uses batched writes to enable robust user following/unfollowing functionality.

The existing follow/unfollow feature was encountering "permission-denied" errors due to restrictive Firestore rules on the `followers` and `following` subcollections. This PR resolves these errors by updating the rules and ensures data consistency by switching to atomic batched writes for follow/unfollow operations.

---
<a href="https://cursor.com/background-agent?bcId=bc-3c57b872-87a5-47b5-8727-be21e21cc53e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3c57b872-87a5-47b5-8727-be21e21cc53e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

