### PR TITLE
Fix organization creation permission denied error

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -107,6 +107,21 @@ service cloud.firestore {
          request.auth.uid in get(/databases/$(database)/documents/Events/$(eventId)).data.coHosts);
     }
     
+    // Organizations: allow authenticated users to create; owner or admins can modify
+    match /Organizations/{organizationId} {
+      // Read allowed for authenticated users (adjust as needed)
+      allow read: if request.auth != null;
+      
+      // Create allowed for any authenticated user creating an org document
+      allow create: if request.auth != null;
+      
+      // Updates/deletes restricted to owner or admins list if present
+      allow update, delete: if request.auth != null && (
+        request.auth.uid == resource.data.ownerUid ||
+        (resource.data.adminUids != null && request.auth.uid in resource.data.adminUids)
+      );
+    }
+    
     // Allow authenticated users to create and read tickets
     // Users can create tickets for events that have tickets enabled
     // Users can read their own tickets


### PR DESCRIPTION
Add Firestore security rules for Organizations collection to allow creation by authenticated users and restrict modifications to owners/admins.

---
<a href="https://cursor.com/background-agent?bcId=bc-cbfdaf86-10e0-4bcc-959a-ff7477ed13af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cbfdaf86-10e0-4bcc-959a-ff7477ed13af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

