### PR TITLE
Fix organization profile screen errors and consolidate modals

### DIFF
--- a/lib/screens/Organizations/organization_profile_screen.dart
+++ b/lib/screens/Organizations/organization_profile_screen.dart
@@ -39,19 +39,6 @@ class OrganizationProfileScreen extends StatelessWidget {
     } catch (_) {}
   }
 
-  void _openAdminTools(BuildContext context) {
-    showModalBottomSheet(
-      context: context,
-      isScrollControlled: true,
-      builder: (ctx) => SafeArea(
-        child: SizedBox(
-          height: MediaQuery.of(ctx).size.height * 0.85,
-          child: _OrgSettingsTab(orgId: organizationId),
-        ),
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
@@ -90,7 +77,10 @@ class OrganizationProfileScreen extends StatelessWidget {
                     return IconButton(
                       tooltip: 'Admin tools',
                       icon: const Icon(Icons.settings),
-                      onPressed: () => _openAdminTools(context),
+                      onPressed: () => showOrgManagementModalForOrganization(
+                        context,
+                        organizationId,
+                      ),
                     );
                   },
                 );
@@ -445,6 +435,7 @@ class _MemberCard extends StatelessWidget {
         onTap: userId == null
             ? null
             : () async {
+                final navigator = Navigator.of(context);
                 try {
                   final doc = await FirebaseFirestore.instance
                       .collection('Customers')
@@ -483,7 +474,7 @@ class _MemberCard extends StatelessWidget {
                     favorites: List<String>.from(d['favorites'] ?? const []),
                     createdAt: parsedCreatedAt,
                   );
-                  Navigator.of(context).push(
+                  navigator.push(
                     MaterialPageRoute(
                       builder: (_) => UserProfileScreen(
                         user: user,
@@ -1321,4 +1312,20 @@ class _OrgSettingsTab extends StatelessWidget {
       }
     } catch (_) {}
   }
+}
+
+void showOrgManagementModalForOrganization(
+  BuildContext context,
+  String organizationId,
+) {
+  showModalBottomSheet(
+    context: context,
+    isScrollControlled: true,
+    builder: (ctx) => SafeArea(
+      child: SizedBox(
+        height: MediaQuery.of(ctx).size.height * 0.85,
+        child: _OrgSettingsTab(orgId: organizationId),
+      ),
+    ),
+  );
 }


### PR DESCRIPTION
Consolidate organization management modal logic and fix `BuildContext` lint errors in `organization_profile_screen.dart`.

---
<a href="https://cursor.com/background-agent?bcId=bc-682344ee-4dcb-4ad1-9383-d64dcaeb3d34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-682344ee-4dcb-4ad1-9383-d64dcaeb3d34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

