### PR TITLE
Standardize share button icon across app

### DIFF
--- a/lib/screens/Events/Attendance/attendance_sheet_screen.dart
+++ b/lib/screens/Events/Attendance/attendance_sheet_screen.dart
@@ -304,7 +304,7 @@ class _AttendanceSheetScreenState extends State<AttendanceSheetScreen> {
                         elevation: 0,
                       ),
                       icon: const Icon(
-                        Icons.share_rounded,
+                        Icons.share_outlined,
                         color: Colors.white,
                       ),
                       label: const Text(

--- a/lib/screens/Events/event_location_view_screen.dart
+++ b/lib/screens/Events/event_location_view_screen.dart
@@ -397,7 +397,7 @@ class _EventLocationViewScreenState extends State<EventLocationViewScreen>
                   child: Row(
                     children: [
                       const Icon(
-                        Icons.share,
+                        Icons.share_outlined,
                         color: Color(0xFF667EEA),
                         size: 20,
                       ),
@@ -649,7 +649,7 @@ class _EventLocationViewScreenState extends State<EventLocationViewScreen>
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    const Icon(Icons.share, color: Colors.white, size: 20),
+                    const Icon(Icons.share_outlined, color: Colors.white, size: 20),
                     const SizedBox(width: 8),
                     Text(
                       'Share Location',

--- a/lib/screens/Events/single_event_screen.dart
+++ b/lib/screens/Events/single_event_screen.dart
@@ -1881,7 +1881,7 @@ class _SingleEventScreenState extends State<SingleEventScreen>
                     child: Column(
                       children: [
                         _buildShareOption(
-                          icon: Icons.share,
+                          icon: Icons.share_outlined,
                           title: 'Share Event Details',
                           subtitle: 'Share event information with others',
                           onTap: () {
@@ -2412,7 +2412,7 @@ https://outlook.live.com/calendar/0/deeplink/compose?subject=${Uri.encodeCompone
                           ),
                           const SizedBox(width: 16),
                           _buildModernButton(
-                            icon: Icons.share_rounded,
+                            icon: Icons.share_outlined,
                             onTap: () => _showQuickShareOptions(),
                             tooltip: 'Share Event',
                           ),
@@ -2441,7 +2441,7 @@ https://outlook.live.com/calendar/0/deeplink/compose?subject=${Uri.encodeCompone
                           ),
                           const SizedBox(width: 16),
                           _buildModernButton(
-                            icon: Icons.share_rounded,
+                            icon: Icons.share_outlined,
                             onTap: () => _shareEventDetails(),
                             tooltip: 'Share Event',
                           ),

--- a/lib/screens/MyProfile/Widgets/professional_badge_widget.dart
+++ b/lib/screens/MyProfile/Widgets/professional_badge_widget.dart
@@ -504,7 +504,7 @@ class _ProfessionalBadgeWidgetState extends State<ProfessionalBadgeWidget>
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: [
           _buildActionButton(
-            icon: Icons.share,
+            icon: Icons.share_outlined,
             label: 'Share',
             onTap: widget.onShare,
           ),

--- a/lib/screens/MyProfile/badge_screen.dart
+++ b/lib/screens/MyProfile/badge_screen.dart
@@ -555,7 +555,7 @@ class _BadgeScreenState extends State<BadgeScreen>
         Expanded(
           child: ElevatedButton.icon(
             onPressed: _shareBadge,
-            icon: const Icon(Icons.share),
+            icon: const Icon(Icons.share_outlined),
             label: const Text('Share Badge'),
             style: ElevatedButton.styleFrom(
               backgroundColor: AppColors.primaryColor,


### PR DESCRIPTION
Standardize share button icons to `Icons.share_outlined` across the app for consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0c6cace-e9b0-4f07-b7e1-b85cd4ac06a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b0c6cace-e9b0-4f07-b7e1-b85cd4ac06a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

