### PR TITLE
Show user's organizations on event creation

### DIFF
--- a/lib/firebase/organization_helper.dart
+++ b/lib/firebase/organization_helper.dart
@@ -24,10 +24,20 @@ class OrganizationHelper {
 
     return membershipQuery.snapshots().asyncMap((snap) async {
       if (snap.docs.isEmpty) return <Map<String, String>>[];
-      final Set<String> orgIds = {
-        for (final d in snap.docs)
-          (d.data()['organizationId']?.toString() ?? ''),
-      }..removeWhere((e) => e.isEmpty);
+      // Resolve organization IDs from the membership docs. Prefer the stored
+      // field if present, but fall back to the parent path for legacy docs
+      // that may not have `organizationId` saved.
+      final Set<String> orgIds = <String>{};
+      for (final d in snap.docs) {
+        final String? fromField = d.data()['organizationId']?.toString();
+        final String? fromPath = d.reference.parent.parent?.id;
+        final String? resolved =
+            (fromField != null && fromField.isNotEmpty) ? fromField : fromPath;
+        if (resolved != null && resolved.isNotEmpty) {
+          orgIds.add(resolved);
+        }
+      }
+      orgIds.removeWhere((e) => e.isEmpty);
       if (orgIds.isEmpty) return <Map<String, String>>[];
 
       final futures = orgIds.map(
@@ -65,8 +75,10 @@ class OrganizationHelper {
       final List<Map<String, String>> result = [];
       for (final doc in query.docs) {
         try {
-          final orgId = doc.data()['organizationId'] as String?;
-          if (orgId == null) continue;
+          // Prefer stored field, fall back to parent path id for legacy docs
+          final String? orgId =
+              (doc.data()['organizationId'] as String?) ?? doc.reference.parent.parent?.id;
+          if (orgId == null || orgId.isEmpty) continue;
           final orgSnap = await _firestore
               .collection('Organizations')
               .doc(orgId)


### PR DESCRIPTION
Populate Select Organization screen with user's organizations by robustly deriving organization IDs from membership documents.

Previously, the `getUserOrganizationsLite()` and `streamUserOrganizationsLite()` methods in `OrganizationHelper` only looked for the `organizationId` field in membership documents. Many legacy membership documents at `Organizations/{orgId}/Members/{uid}` do not store this field, leading to an empty list on the Select Organization screen for valid members/admins. This PR adds a fallback to derive the organization ID from the document's parent path (`doc.reference.parent.parent?.id`), ensuring all approved member/admin organizations are displayed.

---
<a href="https://cursor.com/background-agent?bcId=bc-d40b1aed-a17a-4158-8ccc-919a76e73c49">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d40b1aed-a17a-4158-8ccc-919a76e73c49">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

