### PR TITLE
Fix organization update permission denied error

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -161,6 +161,12 @@ service cloud.firestore {
       }
     }
     
+    // Collection group access for membership documents across organizations
+    // Needed for collectionGroup('Members') queries such as loading a user's organizations
+    match /{path=**}/Members/{memberId} {
+      allow read: if request.auth != null && resource.data.userId == request.auth.uid;
+    }
+    
     // Allow event hosts and co-hosts to read/write their event analytics
     match /event_analytics/{eventId} {
       allow read, write: if request.auth != null && 


### PR DESCRIPTION
Adds Firestore security rule for `Members` collection group queries to fix organization loading errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-98b43d5b-82ba-4cf9-b8dc-32451fc2809d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-98b43d5b-82ba-4cf9-b8dc-32451fc2809d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

