### PR TITLE
Fix event creation NaN constraints and permissions

### DIFF
--- a/lib/screens/Events/create_event_screen.dart
+++ b/lib/screens/Events/create_event_screen.dart
@@ -50,8 +50,8 @@ class CreateEventScreen extends StatefulWidget {
 
 class _CreateEventScreenState extends State<CreateEventScreen>
     with TickerProviderStateMixin {
-  late final double _screenWidth = MediaQuery.of(context).size.width;
-  late final double _screenHeight = MediaQuery.of(context).size.height;
+  double get _screenWidth => MediaQuery.of(context).size.width;
+  double get _screenHeight => MediaQuery.of(context).size.height;
 
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
 
@@ -1195,22 +1195,24 @@ class _CreateEventScreenState extends State<CreateEventScreen>
                     ),
                   ],
                 ),
-                child: RoundedLoadingButton(
-                  animateOnTap: false,
-                  borderRadius: 16,
+                child: SizedBox(
                   width: double.infinity,
                   height: 56,
-                  controller: _btnCtlr,
-                  onPressed: () => _handleSubmit(),
-                  color: const Color(0xFF667EEA),
-                  elevation: 0,
-                  child: const Text(
-                    'Add New Event',
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontWeight: FontWeight.bold,
-                      fontSize: 16,
-                      fontFamily: 'Roboto',
+                  child: RoundedLoadingButton(
+                    animateOnTap: false,
+                    borderRadius: 16,
+                    controller: _btnCtlr,
+                    onPressed: () => _handleSubmit(),
+                    color: const Color(0xFF667EEA),
+                    elevation: 0,
+                    child: const Text(
+                      'Add New Event',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.bold,
+                        fontSize: 16,
+                        fontFamily: 'Roboto',
+                      ),
                     ),
                   ),
                 ),

--- a/lib/screens/Events/single_event_screen.dart
+++ b/lib/screens/Events/single_event_screen.dart
@@ -1057,41 +1057,43 @@ class _SingleEventScreenState extends State<SingleEventScreen>
                 ],
               ),
               child: SafeArea(
-                child: RoundedLoadingButton(
-                  animateOnTap: true,
-                  borderRadius: 12,
+                child: SizedBox(
                   width: double.infinity,
-                  controller: modalBtnController,
-                  onPressed: () async {
-                    if (formKey.currentState!.validate()) {
-                      formKey.currentState!.save();
+                  child: RoundedLoadingButton(
+                    animateOnTap: true,
+                    borderRadius: 12,
+                    controller: modalBtnController,
+                    onPressed: () async {
+                      if (formKey.currentState!.validate()) {
+                        formKey.currentState!.save();
 
-                      // Collect answers
-                      for (int i = 0; i < questions.length; i++) {
-                        final answer = textControllers[i].text.trim();
-                        if (answer.isNotEmpty) {
-                          attendanceModel.answers.add(
-                            '${questions[i].questionTitle}--ans--$answer',
-                          );
+                        // Collect answers
+                        for (int i = 0; i < questions.length; i++) {
+                          final answer = textControllers[i].text.trim();
+                          if (answer.isNotEmpty) {
+                            attendanceModel.answers.add(
+                              '${questions[i].questionTitle}--ans--$answer',
+                            );
+                          }
                         }
-                      }
 
-                      // Close modal and perform sign-in
-                      Navigator.pop(context);
-                      await _performSignIn(attendanceModel);
-                    } else {
-                      modalBtnController.reset();
-                    }
-                  },
-                  color: AppThemeColor.darkBlueColor,
-                  elevation: 0,
-                  child: const Text(
-                    'Sign In',
-                    style: TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w600,
-                      color: Colors.white,
-                      fontFamily: 'Roboto',
+                        // Close modal and perform sign-in
+                        Navigator.pop(context);
+                        await _performSignIn(attendanceModel);
+                      } else {
+                        modalBtnController.reset();
+                      }
+                    },
+                    color: AppThemeColor.darkBlueColor,
+                    elevation: 0,
+                    child: const Text(
+                      'Sign In',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w600,
+                        color: Colors.white,
+                        fontFamily: 'Roboto',
+                      ),
                     ),
                   ),
                 ),


### PR DESCRIPTION
Fixes `NaN` width constraints on `RoundedLoadingButton` and resolves Firestore permission errors during event ID generation.

The `NaN` width error was caused by `RoundedLoadingButton`'s handling of `double.infinity` for width; wrapping it in a `SizedBox` provides explicit constraints. The Firestore permission error during event ID generation was due to read attempts on non-existent documents, which are blocked by security rules. The ID generation now creates a robust, low-collision ID locally, eliminating the need for Firestore reads.

---
<a href="https://cursor.com/background-agent?bcId=bc-0bd6cb95-2633-49db-b7e0-ead12445680c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0bd6cb95-2633-49db-b7e0-ead12445680c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

