### PR TITLE
Update share button icons to iOS style

### DIFF
--- a/lib/screens/Events/Attendance/attendance_sheet_screen.dart
+++ b/lib/screens/Events/Attendance/attendance_sheet_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:intl/intl.dart';
 import 'package:orgami/firebase/firebase_firestore_helper.dart';
 import 'package:orgami/models/attendance_model.dart';
@@ -302,9 +303,9 @@ class _AttendanceSheetScreenState extends State<AttendanceSheetScreen> {
                         ),
                         padding: const EdgeInsets.symmetric(vertical: 16),
                         elevation: 0,
-                      ),
-                      icon: const Icon(
-                        Icons.share_rounded,
+                                          ),
+                    icon: const Icon(
+                        CupertinoIcons.share,
                         color: Colors.white,
                       ),
                       label: const Text(

--- a/lib/screens/Events/Widget/access_list_management_widget.dart
+++ b/lib/screens/Events/Widget/access_list_management_widget.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:orgami/firebase/firebase_firestore_helper.dart';
 import 'package:orgami/models/customer_model.dart';
 import 'package:orgami/models/event_model.dart';
@@ -128,7 +129,7 @@ class _AccessListManagementWidgetState
                 ),
                 IconButton(
                   onPressed: _shareInviteLink,
-                  icon: const Icon(Icons.link),
+                  icon: const Icon(CupertinoIcons.share),
                   tooltip: 'Share Invite Link',
                 ),
               ],

--- a/lib/screens/Events/event_location_view_screen.dart
+++ b/lib/screens/Events/event_location_view_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:geocoding/geocoding.dart';
 import 'package:orgami/models/event_model.dart';
@@ -397,7 +398,7 @@ class _EventLocationViewScreenState extends State<EventLocationViewScreen>
                   child: Row(
                     children: [
                       const Icon(
-                        Icons.share,
+                        CupertinoIcons.share,
                         color: Color(0xFF667EEA),
                         size: 20,
                       ),
@@ -649,7 +650,7 @@ class _EventLocationViewScreenState extends State<EventLocationViewScreen>
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    const Icon(Icons.share, color: Colors.white, size: 20),
+                    const Icon(CupertinoIcons.share, color: Colors.white, size: 20),
                     const SizedBox(width: 8),
                     Text(
                       'Share Location',

--- a/lib/screens/Events/single_event_screen.dart
+++ b/lib/screens/Events/single_event_screen.dart
@@ -1856,7 +1856,7 @@ class _SingleEventScreenState extends State<SingleEventScreen>
                           borderRadius: BorderRadius.circular(12),
                         ),
                         child: Icon(
-                          Icons.share,
+                          CupertinoIcons.share,
                           color: AppThemeColor.darkBlueColor,
                           size: 24,
                         ),
@@ -1885,7 +1885,7 @@ class _SingleEventScreenState extends State<SingleEventScreen>
                     child: Column(
                       children: [
                         _buildShareOption(
-                          icon: Icons.share,
+                          icon: CupertinoIcons.share,
                           title: 'Share Event Details',
                           subtitle: 'Share event information with others',
                           onTap: () {
@@ -2416,7 +2416,7 @@ https://outlook.live.com/calendar/0/deeplink/compose?subject=${Uri.encodeCompone
                           ),
                           const SizedBox(width: 16),
                           _buildModernButton(
-                            icon: Icons.share_rounded,
+                            icon: CupertinoIcons.share,
                             onTap: () => _showQuickShareOptions(),
                             tooltip: 'Share Event',
                           ),
@@ -2445,7 +2445,7 @@ https://outlook.live.com/calendar/0/deeplink/compose?subject=${Uri.encodeCompone
                           ),
                           const SizedBox(width: 16),
                           _buildModernButton(
-                            icon: Icons.share_rounded,
+                            icon: CupertinoIcons.share,
                             onTap: () => _shareEventDetails(),
                             tooltip: 'Share Event',
                           ),

--- a/lib/screens/MyProfile/Widgets/professional_badge_widget.dart
+++ b/lib/screens/MyProfile/Widgets/professional_badge_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import '../../../models/badge_model.dart';
 import '../../../Utils/colors.dart';
@@ -504,7 +505,7 @@ class _ProfessionalBadgeWidgetState extends State<ProfessionalBadgeWidget>
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: [
           _buildActionButton(
-            icon: Icons.share,
+            icon: CupertinoIcons.share,
             label: 'Share',
             onTap: widget.onShare,
           ),

--- a/lib/screens/MyProfile/badge_screen.dart
+++ b/lib/screens/MyProfile/badge_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 // import 'package:flutter/services.dart'; // Unused
 import 'package:share_plus/share_plus.dart';
 import 'dart:io';
@@ -555,7 +556,7 @@ class _BadgeScreenState extends State<BadgeScreen>
         Expanded(
           child: ElevatedButton.icon(
             onPressed: _shareBadge,
-            icon: const Icon(Icons.share),
+            icon: const Icon(CupertinoIcons.share),
             label: const Text('Share Badge'),
             style: ElevatedButton.styleFrom(
               backgroundColor: AppColors.primaryColor,

--- a/lib/screens/MyProfile/user_profile_screen.dart
+++ b/lib/screens/MyProfile/user_profile_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 import 'package:orgami/models/customer_model.dart';
 import 'package:orgami/models/event_model.dart';
@@ -249,7 +250,7 @@ class _UserProfileScreenState extends State<UserProfileScreen>
                   borderRadius: BorderRadius.circular(12),
                 ),
                 child: const Icon(
-                  Icons.share_outlined,
+                  CupertinoIcons.share,
                   color: AppThemeColor.pureWhiteColor,
                   size: 20,
                 ),

--- a/lib/screens/Organizations/organization_profile_screen.dart
+++ b/lib/screens/Organizations/organization_profile_screen.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:orgami/firebase/organization_helper.dart';
 import 'package:orgami/firebase/firebase_storage_helper.dart';
 import 'package:orgami/screens/Organizations/join_requests_screen.dart';
@@ -149,7 +150,7 @@ class OrganizationProfileScreen extends StatelessWidget {
           actions: [
             IconButton(
               tooltip: 'Share',
-              icon: const Icon(Icons.share_outlined),
+              icon: const Icon(CupertinoIcons.share),
               onPressed: () => _shareOrganization(context),
             ),
           ],


### PR DESCRIPTION
Update share button icons to iOS-style `CupertinoIcons.share` for design consistency across specified screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-cbe81402-cad4-432e-b8d2-f8288dad2ff6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cbe81402-cad4-432e-b8d2-f8288dad2ff6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

