### PR TITLE
Change app's initial screen to second splash

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:orgami/firebase_options.dart';
-import 'package:orgami/Screens/Splash/splash_screen.dart';
+import 'package:orgami/screens/Splash/second_splash_screen.dart';
 import 'package:orgami/Utils/logger.dart';
 import 'package:orgami/Utils/theme_provider.dart';
 import 'package:provider/provider.dart';
@@ -85,7 +85,7 @@ class MyApp extends StatelessWidget {
           darkTheme: themeProvider.darkTheme,
           themeMode: themeProvider.themeMode,
           navigatorKey: appNavigatorKey,
-          home: homeOverride ?? const SplashScreen(),
+          home: homeOverride ?? const SecondSplashScreen(),
         );
       },
     );


### PR DESCRIPTION
Set `SecondSplashScreen` as the initial app screen to ensure the correct splash flow on launch.

---
<a href="https://cursor.com/background-agent?bcId=bc-3b4f215e-2128-4e42-a351-b58f57e8917a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3b4f215e-2128-4e42-a351-b58f57e8917a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

