### PR TITLE
Rename organizations to groups

### DIFF
--- a/lib/screens/Home/dashboard_screen.dart
+++ b/lib/screens/Home/dashboard_screen.dart
@@ -3,7 +3,7 @@ import 'package:orgami/Screens/Home/home_hub_screen.dart';
 import 'package:orgami/screens/MyProfile/my_profile_screen.dart';
 import 'package:orgami/Screens/Home/notifications_screen.dart';
 import 'package:orgami/Screens/Messaging/messaging_screen.dart';
-import 'package:orgami/screens/Organizations/organizations_screen.dart';
+import 'package:orgami/screens/Organizations/groups_screen.dart';
 import 'package:orgami/Screens/Home/account_screen.dart';
 
 class DashboardScreen extends StatefulWidget {
@@ -22,7 +22,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
 
   final List<Widget> _dashBoardScreens = const [
     HomeHubScreen(),
-    OrganizationsScreen(),
+    GroupsScreen(),
     MessagingScreen(),
     MyProfileScreen(showBackButton: false),
     NotificationsScreen(),

--- a/lib/screens/Organizations/groups_screen.dart
+++ b/lib/screens/Organizations/groups_screen.dart
@@ -5,14 +5,14 @@ import 'package:orgami/firebase/organization_helper.dart';
 import 'package:orgami/screens/Organizations/organization_profile_screen.dart';
 import 'package:orgami/screens/Organizations/create_organization_screen.dart';
 
-class OrganizationsScreen extends StatefulWidget {
-  const OrganizationsScreen({super.key});
+class GroupsScreen extends StatefulWidget {
+  const GroupsScreen({super.key});
 
   @override
-  State<OrganizationsScreen> createState() => _OrganizationsScreenState();
+  State<GroupsScreen> createState() => _GroupsScreenState();
 }
 
-class _OrganizationsScreenState extends State<OrganizationsScreen> {
+class _GroupsScreenState extends State<GroupsScreen> {
   final TextEditingController _searchCtlr = TextEditingController();
   List<Map<String, String>> _myOrgs = [];
   List<Map<String, dynamic>> _discoverOrgs = [];
@@ -98,10 +98,10 @@ class _OrganizationsScreenState extends State<OrganizationsScreen> {
         scrolledUnderElevation: 0,
         surfaceTintColor: Colors.transparent,
         systemOverlayStyle: SystemUiOverlayStyle.dark,
-        title: const Text('Organizations'),
+        title: const Text('Groups'),
         actions: [
           IconButton(
-            tooltip: 'Create Organization',
+            tooltip: 'Create Group',
             icon: const Icon(Icons.add_business),
             onPressed: _goToCreate,
           ),
@@ -125,7 +125,7 @@ class _OrganizationsScreenState extends State<OrganizationsScreen> {
                       controller: _searchCtlr,
                       textInputAction: TextInputAction.search,
                       decoration: InputDecoration(
-                        hintText: 'Search organizations',
+                        hintText: 'Search groups',
                         prefixIcon: const Icon(Icons.search),
                         border: OutlineInputBorder(
                           borderRadius: BorderRadius.circular(12),
@@ -136,7 +136,7 @@ class _OrganizationsScreenState extends State<OrganizationsScreen> {
                     ),
                     const SizedBox(height: 16),
                     const Text(
-                      'My Organizations',
+                      'My Groups',
                       style: TextStyle(fontWeight: FontWeight.w700),
                     ),
                     const SizedBox(height: 8),
@@ -297,7 +297,7 @@ class _EmptyStateCard extends StatelessWidget {
           const Icon(Icons.info_outline, color: Color(0xFF6B7280)),
           const SizedBox(width: 12),
           const Expanded(
-            child: Text('You have not joined any organizations yet.'),
+            child: Text('You have not joined any groups yet.'),
           ),
           const SizedBox(width: 12),
           FilledButton(onPressed: onCreate, child: const Text('Create')),
@@ -306,3 +306,4 @@ class _EmptyStateCard extends StatelessWidget {
     );
   }
 }
+

--- a/lib/screens/Organizations/organizations_tab.dart
+++ b/lib/screens/Organizations/organizations_tab.dart
@@ -51,10 +51,10 @@ class _OrganizationsTabState extends State<OrganizationsTab> {
         scrolledUnderElevation: 0,
         surfaceTintColor: Colors.transparent,
         systemOverlayStyle: SystemUiOverlayStyle.dark,
-        title: const Text('Organizations'),
+        title: const Text('Groups'),
         actions: [
           IconButton(
-            tooltip: 'Create Organization',
+            tooltip: 'Create Group',
             icon: const Icon(Icons.add_business),
             onPressed: () async {
               await Navigator.push(
@@ -76,7 +76,7 @@ class _OrganizationsTabState extends State<OrganizationsTab> {
       body: _loading
           ? const Center(child: CircularProgressIndicator())
           : _orgs.isEmpty
-          ? const Center(child: Text('No organizations yet'))
+          ? const Center(child: Text('No groups yet'))
           : ListView.separated(
               itemCount: _orgs.length,
               separatorBuilder: (_, __) => const Divider(height: 0),


### PR DESCRIPTION
Rename 'Organizations' screen and all related UI text to 'Groups' as per user request.

---
<a href="https://cursor.com/background-agent?bcId=bc-a2e89445-89fa-4545-a974-1e17b348e651">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a2e89445-89fa-4545-a974-1e17b348e651">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

