### PR TITLE
Fix dart analysis errors and warnings

### DIFF
--- a/lib/Utils/responsive_helper.dart
+++ b/lib/Utils/responsive_helper.dart
@@ -1,0 +1,287 @@
+import 'package:flutter/material.dart';
+
+enum DeviceType {
+  phone,
+  tablet,
+  desktop,
+  largeDesktop,
+}
+
+class ResponsiveHelper {
+  // Device type breakpoints
+  static const double phoneBreakpoint = 600;
+  static const double tabletBreakpoint = 900;
+  static const double desktopBreakpoint = 1600;
+
+  // Get device type based on screen width
+  static DeviceType getDeviceType(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+    
+    if (width < phoneBreakpoint) {
+      return DeviceType.phone;
+    } else if (width < tabletBreakpoint) {
+      return DeviceType.tablet;
+    } else if (width < desktopBreakpoint) {
+      return DeviceType.desktop;
+    } else {
+      return DeviceType.largeDesktop;
+    }
+  }
+
+  // Check if device is phone
+  static bool isPhone(BuildContext context) {
+    return getDeviceType(context) == DeviceType.phone;
+  }
+
+  // Check if device is tablet
+  static bool isTablet(BuildContext context) {
+    return getDeviceType(context) == DeviceType.tablet;
+  }
+
+  // Check if device is desktop
+  static bool isDesktop(BuildContext context) {
+    final deviceType = getDeviceType(context);
+    return deviceType == DeviceType.desktop || deviceType == DeviceType.largeDesktop;
+  }
+
+  // Get responsive padding
+  static EdgeInsets getResponsivePadding(BuildContext context) {
+    final deviceType = getDeviceType(context);
+    switch (deviceType) {
+      case DeviceType.phone:
+        return const EdgeInsets.all(16);
+      case DeviceType.tablet:
+        return const EdgeInsets.all(20);
+      case DeviceType.desktop:
+      case DeviceType.largeDesktop:
+        return const EdgeInsets.all(24);
+    }
+  }
+
+  // Get responsive margin
+  static EdgeInsets getResponsiveMargin(BuildContext context) {
+    final deviceType = getDeviceType(context);
+    switch (deviceType) {
+      case DeviceType.phone:
+        return const EdgeInsets.all(8);
+      case DeviceType.tablet:
+        return const EdgeInsets.all(12);
+      case DeviceType.desktop:
+      case DeviceType.largeDesktop:
+        return const EdgeInsets.all(16);
+    }
+  }
+
+  // Get responsive font size
+  static double getResponsiveFontSize(
+    BuildContext context, {
+    double? phone,
+    double? tablet,
+    double? desktop,
+  }) {
+    final deviceType = getDeviceType(context);
+    switch (deviceType) {
+      case DeviceType.phone:
+        return phone ?? 16;
+      case DeviceType.tablet:
+        return tablet ?? phone ?? 18;
+      case DeviceType.desktop:
+      case DeviceType.largeDesktop:
+        return desktop ?? tablet ?? phone ?? 20;
+    }
+  }
+
+  // Get responsive spacing
+  static double getResponsiveSpacing(BuildContext context) {
+    final deviceType = getDeviceType(context);
+    switch (deviceType) {
+      case DeviceType.phone:
+        return 8;
+      case DeviceType.tablet:
+        return 12;
+      case DeviceType.desktop:
+      case DeviceType.largeDesktop:
+        return 16;
+    }
+  }
+
+  // Get responsive button height
+  static double getResponsiveButtonHeight(BuildContext context) {
+    final deviceType = getDeviceType(context);
+    switch (deviceType) {
+      case DeviceType.phone:
+        return 48;
+      case DeviceType.tablet:
+        return 52;
+      case DeviceType.desktop:
+      case DeviceType.largeDesktop:
+        return 56;
+    }
+  }
+
+  // Get responsive icon size
+  static double getResponsiveIconSize(
+    BuildContext context, {
+    double? phone,
+    double? tablet,
+    double? desktop,
+  }) {
+    final deviceType = getDeviceType(context);
+    switch (deviceType) {
+      case DeviceType.phone:
+        return phone ?? 24;
+      case DeviceType.tablet:
+        return tablet ?? phone ?? 28;
+      case DeviceType.desktop:
+      case DeviceType.largeDesktop:
+        return desktop ?? tablet ?? phone ?? 32;
+    }
+  }
+
+  // Get responsive avatar size
+  static double getResponsiveAvatarSize(BuildContext context) {
+    final deviceType = getDeviceType(context);
+    switch (deviceType) {
+      case DeviceType.phone:
+        return 80;
+      case DeviceType.tablet:
+        return 100;
+      case DeviceType.desktop:
+      case DeviceType.largeDesktop:
+        return 120;
+    }
+  }
+
+  // Get responsive border radius
+  static double getResponsiveBorderRadius(BuildContext context) {
+    final deviceType = getDeviceType(context);
+    switch (deviceType) {
+      case DeviceType.phone:
+        return 8;
+      case DeviceType.tablet:
+        return 12;
+      case DeviceType.desktop:
+      case DeviceType.largeDesktop:
+        return 16;
+    }
+  }
+
+  // Get responsive elevation
+  static double getResponsiveElevation(BuildContext context) {
+    final deviceType = getDeviceType(context);
+    switch (deviceType) {
+      case DeviceType.phone:
+        return 2;
+      case DeviceType.tablet:
+        return 4;
+      case DeviceType.desktop:
+      case DeviceType.largeDesktop:
+        return 6;
+    }
+  }
+
+  // Get responsive grid delegate
+  static SliverGridDelegate getResponsiveGridDelegate(BuildContext context) {
+    final deviceType = getDeviceType(context);
+    switch (deviceType) {
+      case DeviceType.phone:
+        return const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 1,
+          childAspectRatio: 1.5,
+          crossAxisSpacing: 8,
+          mainAxisSpacing: 8,
+        );
+      case DeviceType.tablet:
+        return const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 2,
+          childAspectRatio: 1.5,
+          crossAxisSpacing: 12,
+          mainAxisSpacing: 12,
+        );
+      case DeviceType.desktop:
+      case DeviceType.largeDesktop:
+        return const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 3,
+          childAspectRatio: 1.5,
+          crossAxisSpacing: 16,
+          mainAxisSpacing: 16,
+        );
+    }
+  }
+
+  // Get max content width for large screens
+  static double getMaxContentWidth(BuildContext context) {
+    final deviceType = getDeviceType(context);
+    switch (deviceType) {
+      case DeviceType.phone:
+      case DeviceType.tablet:
+        return double.infinity;
+      case DeviceType.desktop:
+        return 1200;
+      case DeviceType.largeDesktop:
+        return 1400;
+    }
+  }
+
+  // Get responsive aspect ratio
+  static double getResponsiveAspectRatio(BuildContext context) {
+    final deviceType = getDeviceType(context);
+    switch (deviceType) {
+      case DeviceType.phone:
+        return 16 / 9;
+      case DeviceType.tablet:
+        return 4 / 3;
+      case DeviceType.desktop:
+      case DeviceType.largeDesktop:
+        return 21 / 9;
+    }
+  }
+
+  // Check if should show side navigation
+  static bool shouldShowSideNavigation(BuildContext context) {
+    return isDesktop(context);
+  }
+
+  // Build responsive layout
+  static Widget buildResponsiveLayout({
+    required BuildContext context,
+    required Widget phone,
+    Widget? tablet,
+    Widget? desktop,
+  }) {
+    final deviceType = getDeviceType(context);
+    switch (deviceType) {
+      case DeviceType.phone:
+        return phone;
+      case DeviceType.tablet:
+        return tablet ?? phone;
+      case DeviceType.desktop:
+      case DeviceType.largeDesktop:
+        return desktop ?? tablet ?? phone;
+    }
+  }
+}
+
+// Extension methods for convenient access
+extension ResponsiveContext on BuildContext {
+  DeviceType get deviceType => ResponsiveHelper.getDeviceType(this);
+  
+  bool get isPhone => ResponsiveHelper.isPhone(this);
+  bool get isTablet => ResponsiveHelper.isTablet(this);
+  bool get isDesktop => ResponsiveHelper.isDesktop(this);
+  
+  EdgeInsets responsivePadding() => ResponsiveHelper.getResponsivePadding(this);
+  EdgeInsets responsiveMargin() => ResponsiveHelper.getResponsiveMargin(this);
+  double responsiveFontSize({double? phone, double? tablet, double? desktop}) =>
+      ResponsiveHelper.getResponsiveFontSize(this, phone: phone, tablet: tablet, desktop: desktop);
+  double responsiveSpacing() => ResponsiveHelper.getResponsiveSpacing(this);
+  double responsiveButtonHeight() => ResponsiveHelper.getResponsiveButtonHeight(this);
+  double responsiveIconSize({double? phone, double? tablet, double? desktop}) =>
+      ResponsiveHelper.getResponsiveIconSize(this, phone: phone, tablet: tablet, desktop: desktop);
+  double responsiveAvatarSize() => ResponsiveHelper.getResponsiveAvatarSize(this);
+  double responsiveBorderRadius() => ResponsiveHelper.getResponsiveBorderRadius(this);
+  double responsiveElevation() => ResponsiveHelper.getResponsiveElevation(this);
+  double maxContentWidth() => ResponsiveHelper.getMaxContentWidth(this);
+  double responsiveAspectRatio() => ResponsiveHelper.getResponsiveAspectRatio(this);
+  bool shouldShowSideNavigation() => ResponsiveHelper.shouldShowSideNavigation(this);
+}

--- a/lib/Utils/responsive_test_helper.dart
+++ b/lib/Utils/responsive_test_helper.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import 'package:attendus/Utils/responsive_helper.dart';
+import 'package:attendus/Utils/colors.dart';
+import 'package:attendus/Utils/dimensions.dart';
+
+class ResponsiveTestHelper {
+  static Widget buildTestCard(BuildContext context, String title, Widget content) {
+    return Container(
+      margin: ResponsiveHelper.getResponsiveMargin(context),
+      padding: ResponsiveHelper.getResponsivePadding(context),
+      decoration: BoxDecoration(
+        color: AppThemeColor.pureWhiteColor,
+        borderRadius: BorderRadius.circular(
+          ResponsiveHelper.getResponsiveBorderRadius(context),
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.1),
+            blurRadius: ResponsiveHelper.getResponsiveElevation(context),
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: TextStyle(
+              fontSize: ResponsiveHelper.getResponsiveFontSize(
+                context,
+                phone: 18,
+                tablet: 20,
+                desktop: 22,
+              ),
+              fontWeight: FontWeight.bold,
+              color: AppThemeColor.darkBlueColor,
+            ),
+          ),
+          SizedBox(height: ResponsiveHelper.getResponsiveSpacing(context)),
+          content,
+        ],
+      ),
+    );
+  }
+
+  static Widget buildDeviceInfo(BuildContext context) {
+    final deviceType = ResponsiveHelper.getDeviceType(context);
+    final screenSize = MediaQuery.of(context).size;
+    
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Device Type: ${deviceType.name}'),
+        Text('Screen Width: ${screenSize.width.toStringAsFixed(1)}px'),
+        Text('Screen Height: ${screenSize.height.toStringAsFixed(1)}px'),
+        Text('Is Phone: ${context.isPhone}'),
+        Text('Is Tablet: ${context.isTablet}'),
+        Text('Is Desktop: ${context.isDesktop}'),
+      ],
+    );
+  }
+
+  static Widget buildResponsiveValues(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Font Size: ${ResponsiveHelper.getResponsiveFontSize(context)}'),
+        Text('Padding: ${ResponsiveHelper.getResponsivePadding(context)}'),
+        Text('Spacing: ${ResponsiveHelper.getResponsiveSpacing(context)}'),
+        Text('Button Height: ${ResponsiveHelper.getResponsiveButtonHeight(context)}'),
+        Text('Icon Size: ${ResponsiveHelper.getResponsiveIconSize(context)}'),
+        Text('Avatar Size: ${ResponsiveHelper.getResponsiveAvatarSize(context)}'),
+        Text('Border Radius: ${ResponsiveHelper.getResponsiveBorderRadius(context)}'),
+        Text('Elevation: ${ResponsiveHelper.getResponsiveElevation(context)}'),
+      ],
+    );
+  }
+
+  static Widget buildSampleButton(BuildContext context) {
+    return SizedBox(
+      height: ResponsiveHelper.getResponsiveButtonHeight(context),
+      child: ElevatedButton.icon(
+        onPressed: () {},
+        icon: Icon(
+          Icons.touch_app,
+          size: ResponsiveHelper.getResponsiveIconSize(context),
+        ),
+        label: Text(
+          'Sample Button',
+          style: TextStyle(
+            fontSize: ResponsiveHelper.getResponsiveFontSize(context),
+          ),
+        ),
+        style: ElevatedButton.styleFrom(
+          backgroundColor: AppThemeColor.darkBlueColor,
+          foregroundColor: AppThemeColor.pureWhiteColor,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(
+              ResponsiveHelper.getResponsiveBorderRadius(context),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  static Widget buildSampleAvatar(BuildContext context) {
+    final avatarSize = ResponsiveHelper.getResponsiveAvatarSize(context);
+    return Container(
+      width: avatarSize,
+      height: avatarSize,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: AppThemeColor.darkBlueColor.withOpacity(0.1),
+        border: Border.all(
+          color: AppThemeColor.darkBlueColor,
+          width: 2,
+        ),
+      ),
+      child: Icon(
+        Icons.person,
+        size: avatarSize * 0.5,
+        color: AppThemeColor.darkBlueColor,
+      ),
+    );
+  }
+
+  static Widget buildGridExample(BuildContext context) {
+    return SizedBox(
+      height: 200,
+      child: GridView.builder(
+        gridDelegate: ResponsiveHelper.getResponsiveGridDelegate(context),
+        itemCount: 6,
+        itemBuilder: (context, index) {
+          return Container(
+            decoration: BoxDecoration(
+              color: AppThemeColor.darkBlueColor.withOpacity(0.1),
+              borderRadius: BorderRadius.circular(
+                ResponsiveHelper.getResponsiveBorderRadius(context),
+              ),
+            ),
+            child: Center(
+              child: Text(
+                'Item ${index + 1}',
+                style: TextStyle(
+                  fontSize: ResponsiveHelper.getResponsiveFontSize(context),
+                  color: AppThemeColor.darkBlueColor,
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/Test/responsive_test_screen.dart
+++ b/lib/screens/Test/responsive_test_screen.dart
@@ -1,0 +1,324 @@
+import 'package:flutter/material.dart';
+import 'package:attendus/Utils/responsive_helper.dart';
+import 'package:attendus/Utils/responsive_test_helper.dart';
+import 'package:attendus/Utils/colors.dart';
+import 'package:attendus/Utils/dimensions.dart';
+
+class ResponsiveTestScreen extends StatelessWidget {
+  const ResponsiveTestScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFFFAFBFC),
+      appBar: AppBar(
+        title: const Text('Responsive Design Test'),
+        backgroundColor: AppThemeColor.darkBlueColor,
+        foregroundColor: AppThemeColor.pureWhiteColor,
+        elevation: 0,
+      ),
+      body: Container(
+        constraints: BoxConstraints(
+          maxWidth: ResponsiveHelper.getMaxContentWidth(context),
+        ),
+        child: SingleChildScrollView(
+          padding: ResponsiveHelper.getResponsivePadding(context),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Device Information
+              ResponsiveTestHelper.buildTestCard(
+                context,
+                'Device Information',
+                ResponsiveTestHelper.buildDeviceInfo(context),
+              ),
+              
+              SizedBox(height: ResponsiveHelper.getResponsiveSpacing(context)),
+              
+              // Responsive Values
+              ResponsiveTestHelper.buildTestCard(
+                context,
+                'Responsive Values',
+                ResponsiveTestHelper.buildResponsiveValues(context),
+              ),
+              
+              SizedBox(height: ResponsiveHelper.getResponsiveSpacing(context)),
+              
+              // Layout Examples
+              ResponsiveTestHelper.buildTestCard(
+                context,
+                'Layout Examples',
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text('Responsive Layout:'),
+                    SizedBox(height: ResponsiveHelper.getResponsiveSpacing(context)),
+                    ResponsiveHelper.buildResponsiveLayout(
+                      context: context,
+                      phone: _buildPhoneLayout(context),
+                      tablet: _buildTabletLayout(context),
+                      desktop: _buildDesktopLayout(context),
+                    ),
+                  ],
+                ),
+              ),
+              
+              SizedBox(height: ResponsiveHelper.getResponsiveSpacing(context)),
+              
+              // Button Examples
+              ResponsiveTestHelper.buildTestCard(
+                context,
+                'Button Examples',
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    ResponsiveTestHelper.buildSampleButton(context),
+                    SizedBox(height: ResponsiveHelper.getResponsiveSpacing(context)),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: OutlinedButton(
+                            onPressed: () {},
+                            style: OutlinedButton.styleFrom(
+                              minimumSize: Size(
+                                0,
+                                ResponsiveHelper.getResponsiveButtonHeight(context),
+                              ),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(
+                                  ResponsiveHelper.getResponsiveBorderRadius(context),
+                                ),
+                              ),
+                            ),
+                            child: Text(
+                              'Outlined',
+                              style: TextStyle(
+                                fontSize: ResponsiveHelper.getResponsiveFontSize(context),
+                              ),
+                            ),
+                          ),
+                        ),
+                        SizedBox(width: ResponsiveHelper.getResponsiveSpacing(context)),
+                        Expanded(
+                          child: TextButton(
+                            onPressed: () {},
+                            style: TextButton.styleFrom(
+                              minimumSize: Size(
+                                0,
+                                ResponsiveHelper.getResponsiveButtonHeight(context),
+                              ),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(
+                                  ResponsiveHelper.getResponsiveBorderRadius(context),
+                                ),
+                              ),
+                            ),
+                            child: Text(
+                              'Text Button',
+                              style: TextStyle(
+                                fontSize: ResponsiveHelper.getResponsiveFontSize(context),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              
+              SizedBox(height: ResponsiveHelper.getResponsiveSpacing(context)),
+              
+              // Avatar Examples
+              ResponsiveTestHelper.buildTestCard(
+                context,
+                'Avatar Examples',
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        ResponsiveTestHelper.buildSampleAvatar(context),
+                        SizedBox(width: ResponsiveHelper.getResponsiveSpacing(context)),
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              'User Name',
+                              style: TextStyle(
+                                fontSize: ResponsiveHelper.getResponsiveFontSize(
+                                  context,
+                                  phone: 16,
+                                  tablet: 18,
+                                  desktop: 20,
+                                ),
+                                fontWeight: FontWeight.bold,
+                                color: AppThemeColor.darkBlueColor,
+                              ),
+                            ),
+                            Text(
+                              '@username',
+                              style: TextStyle(
+                                fontSize: ResponsiveHelper.getResponsiveFontSize(
+                                  context,
+                                  phone: 14,
+                                  tablet: 16,
+                                  desktop: 18,
+                                ),
+                                color: AppThemeColor.dullFontColor,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              
+              SizedBox(height: ResponsiveHelper.getResponsiveSpacing(context)),
+              
+              // Grid Examples
+              ResponsiveTestHelper.buildTestCard(
+                context,
+                'Grid Examples',
+                ResponsiveTestHelper.buildGridExample(context),
+              ),
+              
+              SizedBox(height: ResponsiveHelper.getResponsiveSpacing(context)),
+              
+              // Typography Examples
+              ResponsiveTestHelper.buildTestCard(
+                context,
+                'Typography Examples',
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Heading 1',
+                      style: TextStyle(
+                        fontSize: ResponsiveHelper.getResponsiveFontSize(
+                          context,
+                          phone: 24,
+                          tablet: 28,
+                          desktop: 32,
+                        ),
+                        fontWeight: FontWeight.bold,
+                        color: AppThemeColor.darkBlueColor,
+                      ),
+                    ),
+                    SizedBox(height: ResponsiveHelper.getResponsiveSpacing(context) / 2),
+                    Text(
+                      'Heading 2',
+                      style: TextStyle(
+                        fontSize: ResponsiveHelper.getResponsiveFontSize(
+                          context,
+                          phone: 20,
+                          tablet: 24,
+                          desktop: 28,
+                        ),
+                        fontWeight: FontWeight.w600,
+                        color: AppThemeColor.darkBlueColor,
+                      ),
+                    ),
+                    SizedBox(height: ResponsiveHelper.getResponsiveSpacing(context) / 2),
+                    Text(
+                      'Body Text - This is a sample paragraph to demonstrate responsive typography. The font size adapts based on the device type and screen size.',
+                      style: TextStyle(
+                        fontSize: ResponsiveHelper.getResponsiveFontSize(context),
+                        color: AppThemeColor.darkFontColor,
+                        height: 1.5,
+                      ),
+                    ),
+                    SizedBox(height: ResponsiveHelper.getResponsiveSpacing(context) / 2),
+                    Text(
+                      'Caption Text',
+                      style: TextStyle(
+                        fontSize: ResponsiveHelper.getResponsiveFontSize(
+                          context,
+                          phone: 12,
+                          tablet: 14,
+                          desktop: 16,
+                        ),
+                        color: AppThemeColor.dullFontColor,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+  
+  Widget _buildPhoneLayout(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: AppThemeColor.darkBlueColor.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: const Column(
+        children: [
+          Icon(Icons.phone_android, size: 32),
+          SizedBox(height: 8),
+          Text('Phone Layout'),
+          Text('Single column, compact spacing'),
+        ],
+      ),
+    );
+  }
+  
+  Widget _buildTabletLayout(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: AppThemeColor.darkBlueColor.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: const Row(
+        children: [
+          Icon(Icons.tablet, size: 36),
+          SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('Tablet Layout'),
+                Text('Two columns, medium spacing'),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+  
+  Widget _buildDesktopLayout(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(24),
+      decoration: BoxDecoration(
+        color: AppThemeColor.darkBlueColor.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: const Row(
+        children: [
+          Icon(Icons.desktop_mac, size: 40),
+          SizedBox(width: 24),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('Desktop Layout'),
+                Text('Three columns, expanded spacing'),
+              ],
+            ),
+          ),
+          Icon(Icons.keyboard_arrow_right, size: 24),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Add a comprehensive responsive design system to resolve numerous Dart analysis errors caused by missing responsive helper files.

The original Dart analysis errors (181 errors, 79 warnings, 39 hints) were primarily due to references to a non-existent `responsive_helper.dart` file and related components. This PR introduces the `responsive_helper.dart`, `responsive_test_helper.dart`, and `responsive_test_screen.dart` files, which implement the expected responsive design logic and a test screen, thereby resolving the analysis issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b039c74-cecb-4e1f-af86-9cdc35ef69ab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9b039c74-cecb-4e1f-af86-9cdc35ef69ab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

